### PR TITLE
Fix the bug that occurs when parsing the thread call stack.

### DIFF
--- a/Parser.cs
+++ b/Parser.cs
@@ -708,7 +708,7 @@ namespace DumpReport
                     if (Program.is32bitDump) // 32-bits log
                         pattern = @"^\w+\s(?<child>\w+)\s(?<return_addr>\w+)\s(?<args_to_child1>\w+)\s(?<args_to_child2>\w+)\s(?<args_to_child3>\w+)\s(?<call_site>.*)";
                     else // 64-bits log
-                        pattern = @"(?<child>[\w,`]+)\s(?<return_addr>[\w,`]+)\s:\s(?<args_to_child1>[\w,`]+)\s(?<args_to_child2>[\w,`]+)\s(?<args_to_child3>[\w,`]+)\s(?<args_to_child4>[\w,`]+)\s:\s(?<call_site>.*)";
+                        pattern = @"(?<child>[\w,`]+)\s(?<return_addr>[\w,`]+)\s+:\s+(?<args_to_child1>[\w,`]+)\s+(?<args_to_child2>[\w,`]+)\s+(?<args_to_child3>[\w,`]+)\s+(?<args_to_child4>[\w,`]+)\s+:\s+(?<call_site>.*)";
 
                     matches = Regex.Matches(line, pattern);
 


### PR DESCRIPTION
Hello

Thank you for making the DumpReport tool.

While using windbg, I found and modified a phenomenon that the stack was less visible when analyzing the minidump.

Once again, thank you for creating a wonderful tool.

Thank you.