### PR TITLE
Fix the bug that occurs when parsing the 32bit thread call stack

### DIFF
--- a/Parser.cs
+++ b/Parser.cs
@@ -706,7 +706,7 @@ namespace DumpReport
                 else
                 {
                     if (Program.is32bitDump) // 32-bits log
-                        pattern = @"^\w+\s(?<child>\w+)\s(?<return_addr>\w+)\s(?<args_to_child1>\w+)\s(?<args_to_child2>\w+)\s(?<args_to_child3>\w+)\s(?<call_site>.*)";
+                        pattern = @"^\w+\s(?<child>\w+)\s(?<return_addr>\w+)\s+(?<args_to_child1>\w+)\s(?<args_to_child2>\w+)\s(?<args_to_child3>\w+)\s(?<call_site>.*)";
                     else // 64-bits log
                         pattern = @"(?<child>[\w,`]+)\s(?<return_addr>[\w,`]+)\s+:\s+(?<args_to_child1>[\w,`]+)\s+(?<args_to_child2>[\w,`]+)\s+(?<args_to_child3>[\w,`]+)\s+(?<args_to_child4>[\w,`]+)\s+:\s+(?<call_site>.*)";
 


### PR DESCRIPTION
32bit frame stacks didn't seem to be detected, at least not on the latest version of CDB.exe